### PR TITLE
Make data-holder classes abstract + code cleanup

### DIFF
--- a/src/main/java/chaos/unity/nenggao/AbstractLabel.java
+++ b/src/main/java/chaos/unity/nenggao/AbstractLabel.java
@@ -4,6 +4,7 @@ import com.diogonunes.jcolor.AnsiFormat;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@SuppressWarnings("unused")
 public abstract class AbstractLabel {
     public @Nullable AnsiFormat format = null;
     public final @NotNull Span span;

--- a/src/main/java/chaos/unity/nenggao/AbstractLabel.java
+++ b/src/main/java/chaos/unity/nenggao/AbstractLabel.java
@@ -1,0 +1,45 @@
+package chaos.unity.nenggao;
+
+import com.diogonunes.jcolor.AnsiFormat;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class AbstractLabel {
+    public @Nullable AnsiFormat format = null;
+    public final @NotNull Span span;
+    public final @NotNull String message;
+    public @Nullable String hint = null;
+    
+    protected AbstractLabel(@NotNull Span span, @NotNull String message) {
+        this.span = span;
+        this.message = message;
+    }
+    
+    public void setFormat(@NotNull AnsiFormat format) {
+        this.format = format;
+    }
+    
+    public @Nullable AnsiFormat getFormat() {
+        return format;
+    }
+    
+    public void setHint(@NotNull String hint) {
+        this.hint = hint;
+    }
+    
+    public @Nullable String getHint() {
+        return hint;
+    }
+
+    public boolean isInSameLine(int lineNumber) {
+        return span.startPosition.line == lineNumber;
+    }
+
+    public boolean isIn(int line) {
+        return span.isIn(line);
+    }
+
+    public boolean isMultiLine() {
+        return span.isMultiLine();
+    }
+}

--- a/src/main/java/chaos/unity/nenggao/AbstractLabel.java
+++ b/src/main/java/chaos/unity/nenggao/AbstractLabel.java
@@ -7,11 +7,11 @@ import org.jetbrains.annotations.Nullable;
 @SuppressWarnings("unused")
 public abstract class AbstractLabel {
     public @Nullable AnsiFormat format = null;
-    public final @NotNull Span span;
+    public final @NotNull AbstractSpan span;
     public final @NotNull String message;
     public @Nullable String hint = null;
     
-    protected AbstractLabel(@NotNull Span span, @NotNull String message) {
+    protected AbstractLabel(@NotNull AbstractSpan span, @NotNull String message) {
         this.span = span;
         this.message = message;
     }

--- a/src/main/java/chaos/unity/nenggao/AbstractPosition.java
+++ b/src/main/java/chaos/unity/nenggao/AbstractPosition.java
@@ -1,0 +1,11 @@
+package chaos.unity.nenggao;
+
+public abstract class AbstractPosition {
+    public final int line;
+    public final int pos;
+    
+    protected AbstractPosition(int line, int pos) {
+        this.line = line;
+        this.pos = pos;
+    }
+}

--- a/src/main/java/chaos/unity/nenggao/AbstractSpan.java
+++ b/src/main/java/chaos/unity/nenggao/AbstractSpan.java
@@ -1,0 +1,80 @@
+package chaos.unity.nenggao;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@SuppressWarnings("unused")
+public abstract class AbstractSpan {
+    public final @NotNull Position startPosition;
+    public final @NotNull Position endPosition;
+
+    protected AbstractSpan(@NotNull Position startPosition, @NotNull Position endPosition) {
+        this.startPosition = startPosition;
+        this.endPosition = endPosition;
+    }
+
+    public boolean isMultiLine() {
+        return startPosition.line != endPosition.line;
+    }
+
+    public boolean isIn(int line) {
+        return startPosition.line <= line && line <= endPosition.line;
+    }
+
+    /**
+     * get offset of two position, returns -1 when two positions are in different lines or end position is in front of start position.
+     * @return offset of two position.
+     */
+    public int offset() {
+        if (startPosition.line != endPosition.line || startPosition.pos > endPosition.pos) {
+            return -1;
+        }
+        return endPosition.pos - startPosition.pos;
+    }
+
+    /**
+     * expand copy current instance of {@link AbstractSpan} and attempt to extend end position to {@code endSpan}.
+     * If {@code endSpan} is null, returns copy of current instance; if {@code endSpan}'s {@link AbstractSpan#endPosition}
+     * is in front of the current instance's {@link AbstractSpan#startPosition}, returns copy of current instance, otherwise,
+     * returns a copy of current instance, which its {@link AbstractSpan#endPosition} is replaced by {@code endSpan}'s
+     * {@link AbstractSpan#endPosition}.
+     * @param endSpan the span to expand with
+     * @return a copy of current instance, field data would be different based on {@code endSpan}'s data
+     */
+    public abstract @NotNull AbstractSpan expand(@Nullable AbstractSpan endSpan);
+
+    public abstract @NotNull AbstractSpan copy();
+
+    /**
+     * range constructs a span that ignores positions in lines, which is effective when using in source segment capturing.
+     * @param startLineNumber start of range, must be larger than 1.
+     * @param endLineNumber end of range.
+     * @return span based on providing line range
+     */
+    public static AbstractSpan range(int startLineNumber, int endLineNumber) {
+        return multipleLine(startLineNumber, 0, endLineNumber, 0);
+    }
+
+    /**
+     * singleLine constructs a span that only capture a string in single line.
+     * @param lineNumber start and end line, must be larger than 1.
+     * @param start start of span in line.
+     * @param end end of span in line.
+     * @return span.
+     */
+    public static AbstractSpan singleLine(int lineNumber, int start, int end) {
+        return new Span(new Position(lineNumber, start), new Position(lineNumber, end));
+    }
+
+    /**
+     * multipleLine constructs a span with full control of all positions.
+     * @param startLineNumber start line, must be larger than 1.
+     * @param start start of span in start line.
+     * @param endLineNumber end line.
+     * @param end end of span in end line.
+     * @return span.
+     */
+    public static AbstractSpan multipleLine(int startLineNumber, int start, int endLineNumber, int end) {
+        return new Span(new Position(startLineNumber, start), new Position(endLineNumber, end));
+    }
+}

--- a/src/main/java/chaos/unity/nenggao/AbstractSpan.java
+++ b/src/main/java/chaos/unity/nenggao/AbstractSpan.java
@@ -5,10 +5,10 @@ import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("unused")
 public abstract class AbstractSpan {
-    public final @NotNull Position startPosition;
-    public final @NotNull Position endPosition;
+    public final @NotNull AbstractPosition startPosition;
+    public final @NotNull AbstractPosition endPosition;
 
-    protected AbstractSpan(@NotNull Position startPosition, @NotNull Position endPosition) {
+    protected AbstractSpan(@NotNull AbstractPosition startPosition, @NotNull AbstractPosition endPosition) {
         this.startPosition = startPosition;
         this.endPosition = endPosition;
     }

--- a/src/main/java/chaos/unity/nenggao/Error.java
+++ b/src/main/java/chaos/unity/nenggao/Error.java
@@ -4,23 +4,11 @@ import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("unused")
 public class Error extends Report {
-    public @NotNull String tag = "error";
-
-    public Error(@NotNull Position startPosition, @NotNull Position endPosition, @NotNull String message) {
-        super(startPosition, endPosition, ReportType.ERROR, message);
+    public Error(@NotNull AbstractPosition startPosition, @NotNull AbstractPosition endPosition, @NotNull String message) {
+        super("error", startPosition, endPosition, ReportType.ERROR, message);
     }
 
-    public Error(@NotNull Span span, @NotNull String message) {
-        super(span, ReportType.ERROR, message);
-    }
-
-    @Override
-    public void setTag(@NotNull String tag) {
-        this.tag = tag;
-    }
-
-    @Override
-    public @NotNull String getTag() {
-        return tag;
+    public Error(@NotNull AbstractSpan span, @NotNull String message) {
+        super("error", span, ReportType.ERROR, message);
     }
 }

--- a/src/main/java/chaos/unity/nenggao/FileReportBuilder.java
+++ b/src/main/java/chaos/unity/nenggao/FileReportBuilder.java
@@ -62,7 +62,7 @@ public class FileReportBuilder {
         return this;
     }
 
-    public @NotNull ReportBuilder warning(@NotNull Span span, @NotNull String message, @Nullable Object... args) {
+    public @NotNull ReportBuilder warning(@NotNull AbstractSpan span, @NotNull String message, @Nullable Object... args) {
         return new ReportBuilder(this, new Warning(span, String.format(message, args)));
     }
 
@@ -71,7 +71,7 @@ public class FileReportBuilder {
         return this;
     }
 
-    public @NotNull ReportBuilder error(@NotNull Span span, @NotNull String message, @Nullable Object... args) {
+    public @NotNull ReportBuilder error(@NotNull AbstractSpan span, @NotNull String message, @Nullable Object... args) {
         return new ReportBuilder(this, new Error(span, String.format(message, args)));
     }
 
@@ -124,7 +124,7 @@ public class FileReportBuilder {
 
             // Used for mapping multi-line diagnostic spacing
             // Label instance - Is Occupied
-            Map<Label, Boolean> occupiedMultiLineLabels = new LinkedHashMap<>();
+            Map<AbstractLabel, Boolean> occupiedMultiLineLabels = new LinkedHashMap<>();
             List<Line> segment = source.subList(report.commonSpan.startPosition.line, report.commonSpan.endPosition.line);
 
             switch (report.type) {
@@ -144,19 +144,19 @@ public class FileReportBuilder {
 
             writeSourceLocation(printStream, maxNumbersOfDigit, report.commonSpan.startPosition);
 
-            for (Label label : report.labels)
+            for (AbstractLabel label : report.labels)
                 if (label.isMultiLine())
                     occupiedMultiLineLabels.put(label, false);
 
             boolean previousLineRendered = true, renderSource;
-            Label currentDominantLabel = null;
+            AbstractLabel currentDominantLabel = null;
             for (Line line : segment) {
                 StringBuilder lineBuilder = new StringBuilder(line.chars);
-                List<Label> appliedLabels = new LinkedList<>();
+                List<AbstractLabel> appliedLabels = new LinkedList<>();
                 int insertedLen = 0, mostLastPosition = line.len + 1;
                 renderSource = false;
 
-                for (Label label : report.labels) {
+                for (AbstractLabel label : report.labels) {
                     if (label.isIn(line.lineNumber)) {
                         if (!label.isMultiLine()) {
                             if (label.format != null && enableColor) {
@@ -210,7 +210,7 @@ public class FileReportBuilder {
                 previousLineRendered = true;
 
                 writeLineNumber(printStream, line.lineNumber, maxNumbersOfDigit, false);
-                Label endedLabel = writeMultiLineLabel(printStream, line.lineNumber, occupiedMultiLineLabels, null, characterSet.verticalBar);
+                AbstractLabel endedLabel = writeMultiLineLabel(printStream, line.lineNumber, occupiedMultiLineLabels, null, characterSet.verticalBar);
 
                 printStream.append(lineBuilder.toString());
 
@@ -221,7 +221,7 @@ public class FileReportBuilder {
                     writeMultiLineLabel(printStream, -1, occupiedMultiLineLabels, null, characterSet.verticalBar);
 
                     // Render under bars
-                    for (Label label : appliedLabels) {
+                    for (AbstractLabel label : appliedLabels) {
                         int spaceLen = label.span.startPosition.pos - insertedLen;
                         if (spaceLen > 0) // Prevent unnecessary padding
                             printStream.append(new String(new char[spaceLen]).replace('\0', ' '));
@@ -249,7 +249,7 @@ public class FileReportBuilder {
 
                         insertedLen = 0;
                         for (int k = 0; k < appliedLabels.size(); k++) {
-                            Label label = appliedLabels.get(k);
+                            AbstractLabel label = appliedLabels.get(k);
 
                             // Check if it's null, this happens after we set label to null when it's marked printed
                             if (label == null)
@@ -392,7 +392,7 @@ public class FileReportBuilder {
         if (enableColor) printStream.append(Ansi.RESET);
     }
 
-    private void writeSourceLocation(final @NotNull PrintStream printStream, int maxLineDigit, Position startPosition) {
+    private void writeSourceLocation(final @NotNull PrintStream printStream, int maxLineDigit, AbstractPosition startPosition) {
         writeColor(printStream, Attribute.BRIGHT_BLACK_TEXT());
         printStream.format("%" + (maxLineDigit + 2) + "s%s[", characterSet.leftTop, characterSet.horizontalBar);
         writeReset(printStream);
@@ -410,14 +410,17 @@ public class FileReportBuilder {
         writeReset(printStream);
     }
 
-    private @Nullable Label writeMultiLineLabel(final @NotNull PrintStream printStream, int lineNumber, Map<Label, Boolean> labelMap, @Nullable Label terminatedLabel, char verticalBarVariant) {
-        List<Map.Entry<Label, Boolean>> entries = new ArrayList<>(labelMap.entrySet());
+    private @Nullable AbstractLabel writeMultiLineLabel(final @NotNull PrintStream printStream, 
+                                                        int lineNumber, Map<AbstractLabel, Boolean> labelMap, 
+                                                        @Nullable AbstractLabel terminatedLabel, 
+                                                        char verticalBarVariant) {
+        List<Map.Entry<AbstractLabel, Boolean>> entries = new ArrayList<>(labelMap.entrySet());
         boolean shouldPrint = true;
         int lastIndex = 0;
-        Label endedLabel = null;
+        AbstractLabel endedLabel = null;
 
         for (int i = 0; i < entries.size(); i++) {
-            Label label = entries.get(i).getKey();
+            AbstractLabel label = entries.get(i).getKey();
 
             if (entries.get(i).getValue()) {
                 // Render bars and arrow
@@ -497,7 +500,7 @@ public class FileReportBuilder {
             return this;
         }
 
-        public @NotNull LabelBuilder label(@NotNull Span span, @NotNull String message, @Nullable Object... args) {
+        public @NotNull LabelBuilder label(@NotNull AbstractSpan span, @NotNull String message, @Nullable Object... args) {
             return new LabelBuilder(this, new Label(span, String.format(message, args)));
         }
 

--- a/src/main/java/chaos/unity/nenggao/FileReportBuilder.java
+++ b/src/main/java/chaos/unity/nenggao/FileReportBuilder.java
@@ -224,7 +224,7 @@ public class FileReportBuilder {
                     for (AbstractLabel label : appliedLabels) {
                         int spaceLen = label.span.startPosition.pos - insertedLen;
                         if (spaceLen > 0) // Prevent unnecessary padding
-                            printStream.append(new String(new char[spaceLen]).replace('\0', ' '));
+                            printStream.append(repeatChar(spaceLen, ' '));
 
                         int offset = label.span.offset();
                         StringBuilder underlineBuilder = new StringBuilder(offset);
@@ -257,7 +257,7 @@ public class FileReportBuilder {
 
                             int spaceLen = label.span.startPosition.pos - insertedLen, offset = label.span.offset() / 2;
 
-                            printStream.append(new String(new char[spaceLen + offset]).replace('\0', ' '));
+                            printStream.append(repeatChar(spaceLen + offset, ' '));
 
                             insertedLen += spaceLen + offset + 1; // 1 is vertical bar
 
@@ -265,7 +265,7 @@ public class FileReportBuilder {
                                 appliedLabels.set(k, null); // Mark printed
                                 boolean reset = writeColor(printStream, label.format);
                                 printStream.append(String.valueOf(characterSet.leftBottom));
-                                printStream.append(new String(new char[mostLastPosition - insertedLen]).replace('\0', characterSet.horizontalBar));
+                                printStream.append(repeatChar(mostLastPosition - insertedLen, characterSet.horizontalBar));
                                 if (reset) writeReset(printStream);
                                 printStream.append(' ');
                                 printStream.append(label.message);
@@ -276,8 +276,7 @@ public class FileReportBuilder {
                                     writeLineNumber(printStream, -1, maxNumbersOfDigit, true);
                                     writeMultiLineLabel(printStream, -1, occupiedMultiLineLabels, null, characterSet.verticalBar);
 
-                                    printStream.append(new String(new char[spaceLen + offset]).replace('\0', ' '));
-                                    printStream.append(new String(new char[mostLastPosition - insertedLen + 1]).replace('\0', ' '));
+                                    printStream.append(repeatChar(spaceLen + offset + mostLastPosition - insertedLen + 1, ' '));
                                     boolean resetHint = writeColor(printStream, Attribute.BRIGHT_BLUE_TEXT());
                                     printStream.append("!hint: ");
                                     printStream.append(label.hint);
@@ -305,7 +304,7 @@ public class FileReportBuilder {
                     writeMultiLineLabel(printStream, -1, occupiedMultiLineLabels, endedLabel, characterSet.verticalBar);
                     occupiedMultiLineLabels.computeIfPresent(endedLabel, (l, occupied) -> false);
                     boolean reset = writeColor(printStream, endedLabel.format);
-                    printStream.append(new String(new char[mostLastPosition]).replace('\0', characterSet.horizontalBar));
+                    printStream.append(repeatChar(mostLastPosition, characterSet.horizontalBar));
                     if (reset) writeReset(printStream);
                     printStream.format(" %s", endedLabel.message);
 
@@ -315,7 +314,7 @@ public class FileReportBuilder {
                         writeLineNumber(printStream, -1, maxNumbersOfDigit, true);
                         writeMultiLineLabel(printStream, -1, occupiedMultiLineLabels, null, characterSet.verticalBar);
 
-                        printStream.append(new String(new char[mostLastPosition]).replace('\0', ' '));
+                        printStream.append(repeatChar(mostLastPosition, ' '));
                         boolean resetHint = writeColor(printStream, Attribute.BRIGHT_BLUE_TEXT());
                         printStream.append("!hint: ");
                         printStream.append(endedLabel.hint);
@@ -327,7 +326,7 @@ public class FileReportBuilder {
             }
 
             writeColor(printStream, Attribute.BRIGHT_BLACK_TEXT());
-            printStream.append(new String(new char[maxNumbersOfDigit + 1]).replace('\0', characterSet.horizontalBar));
+            printStream.append(repeatChar(maxNumbersOfDigit + 1, characterSet.horizontalBar));
             printStream.append(characterSet.rightBottom);
             writeReset(printStream);
             printStream.append('\n');
@@ -392,7 +391,9 @@ public class FileReportBuilder {
         if (enableColor) printStream.append(Ansi.RESET);
     }
 
-    private void writeSourceLocation(final @NotNull PrintStream printStream, int maxLineDigit, AbstractPosition startPosition) {
+    private void writeSourceLocation(final @NotNull PrintStream printStream, 
+                                     int maxLineDigit, 
+                                     AbstractPosition startPosition) {
         writeColor(printStream, Attribute.BRIGHT_BLACK_TEXT());
         printStream.format("%" + (maxLineDigit + 2) + "s%s[", characterSet.leftTop, characterSet.horizontalBar);
         writeReset(printStream);
@@ -403,7 +404,10 @@ public class FileReportBuilder {
         printStream.append('\n');
     }
 
-    private void writeLineNumber(final @NotNull PrintStream printStream, int lineNumber, int maxLineDigit, boolean isVirtualLine) {
+    private void writeLineNumber(final @NotNull PrintStream printStream, 
+                                 int lineNumber, 
+                                 int maxLineDigit, 
+                                 boolean isVirtualLine) {
         writeColor(printStream, Attribute.BRIGHT_BLACK_TEXT());
         if (isVirtualLine) printStream.format("%" + maxLineDigit + "s %s ", "", characterSet.verticalBarBreaking);
         else printStream.format("%" + maxLineDigit + "d %s ", lineNumber, characterSet.verticalBar);
@@ -428,20 +432,20 @@ public class FileReportBuilder {
 
                 if (label.span.startPosition.line == lineNumber) {
                     printStream.append(characterSet.leftTop);
-                    printStream.append(new String(new char[(entries.size() - i) * 2]).replace('\0', characterSet.horizontalBar));
+                    printStream.append(repeatChar((entries.size() - i) * 2, characterSet.horizontalBar));
                     printStream.append(characterSet.rightArrow);
                     shouldPrint = false;
                     break;
                 } else if (label.span.endPosition.line == lineNumber) {
                     printStream.append(characterSet.leftCross);
-                    printStream.append(new String(new char[(entries.size() - i) * 2]).replace('\0', characterSet.horizontalBar));
+                    printStream.append(repeatChar((entries.size() - i) * 2, characterSet.horizontalBar));
                     printStream.append(characterSet.rightArrow);
                     shouldPrint = false;
                     endedLabel = label;
                     break;
                 } else if (label == terminatedLabel) {
                     printStream.append(characterSet.leftBottom);
-                    printStream.append(new String(new char[(entries.size() - i) * 2 + 2]).replace('\0', characterSet.horizontalBar));
+                    printStream.append(repeatChar((entries.size() - i) * 2 + 2, characterSet.horizontalBar));
                     return null;
                 } else {
                     printStream.append(verticalBarVariant);
@@ -457,10 +461,14 @@ public class FileReportBuilder {
         }
 
         if (shouldPrint)
-            printStream.append(new String(new char[(entries.size() - lastIndex) * 2 + 3]).replace('\0', ' '));
+            printStream.append(repeatChar((entries.size() - lastIndex) * 2 + 3, ' '));
         else printStream.append(' ');
 
         return endedLabel;
+    }
+    
+    private @NotNull String repeatChar(int length, char character) {
+        return new String(new char[length]).replace('\0', character);
     }
 
     /* Windows 10 supports Ansi codes. However, it's still experimental and not enabled by default.

--- a/src/main/java/chaos/unity/nenggao/Label.java
+++ b/src/main/java/chaos/unity/nenggao/Label.java
@@ -1,38 +1,9 @@
 package chaos.unity.nenggao;
 
-import com.diogonunes.jcolor.AnsiFormat;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-public class Label {
-    public @Nullable AnsiFormat format = null;
-    public final @NotNull Span span;
-    public final @NotNull String message;
-    public @Nullable String hint = null;
-
+public class Label extends AbstractLabel {
     public Label(@NotNull Span span, @NotNull String message) {
-        this.span = span;
-        this.message = message;
-    }
-
-
-    public void setHint(@NotNull String hint) {
-        this.hint = hint;
-    }
-
-    public @Nullable String getHint() {
-        return hint;
-    }
-
-    public boolean isInSameLine(int lineNumber) {
-        return span.startPosition.line == lineNumber;
-    }
-
-    public boolean isIn(int line) {
-        return span.isIn(line);
-    }
-
-    public boolean isMultiLine() {
-        return span.isMultiLine();
+        super(span, message);
     }
 }

--- a/src/main/java/chaos/unity/nenggao/Label.java
+++ b/src/main/java/chaos/unity/nenggao/Label.java
@@ -3,7 +3,7 @@ package chaos.unity.nenggao;
 import org.jetbrains.annotations.NotNull;
 
 public class Label extends AbstractLabel {
-    public Label(@NotNull Span span, @NotNull String message) {
+    public Label(@NotNull AbstractSpan span, @NotNull String message) {
         super(span, message);
     }
 }

--- a/src/main/java/chaos/unity/nenggao/Position.java
+++ b/src/main/java/chaos/unity/nenggao/Position.java
@@ -1,11 +1,7 @@
 package chaos.unity.nenggao;
 
-public class Position {
-    public final int line;
-    public final int pos;
-
+public class Position extends AbstractPosition {
     public Position(int line, int pos) {
-        this.line = line;
-        this.pos = pos;
+        super(line, pos);
     }
 }

--- a/src/main/java/chaos/unity/nenggao/Report.java
+++ b/src/main/java/chaos/unity/nenggao/Report.java
@@ -1,35 +1,40 @@
 package chaos.unity.nenggao;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public abstract class Report {
-    public final @NotNull Span commonSpan;
-    public final @NotNull List<@NotNull Label> labels = new ArrayList<>();
+    public @NotNull String tag;
+    public final @NotNull AbstractSpan commonSpan;
+    public final @NotNull List<@NotNull AbstractLabel> labels = new ArrayList<>();
     public final @NotNull ReportType type;
     public final @NotNull String message;
 
-    public Report(@NotNull Position startPosition, @NotNull Position endPosition, @NotNull ReportType type, @NotNull String message) {
-        this.commonSpan = new Span(startPosition, endPosition);
-        this.type = type;
-        this.message = message;
+    public Report(@Nullable String tag, @NotNull AbstractPosition startPosition, @NotNull AbstractPosition endPosition, @NotNull ReportType type, @NotNull String message) {
+        this(tag, new Span(startPosition, endPosition), type, message);
     }
 
-    public Report(@NotNull Span span, @NotNull ReportType type, @NotNull String message) {
+    public Report(@Nullable String tag, @NotNull AbstractSpan span, @NotNull ReportType type, @NotNull String message) {
+        this.tag = tag == null ? "" : tag;
         this.commonSpan = span;
         this.type = type;
         this.message = message;
     }
 
-    public void addLabel(@NotNull Label label) {
+    public void addLabel(@NotNull AbstractLabel label) {
         this.labels.add(label);
     }
 
-    public abstract void setTag(@NotNull String tag);
+    public void setTag(@NotNull String tag) {
+        this.tag = tag;
+    }
 
-    public abstract @NotNull String getTag();
+    public @NotNull String getTag() {
+        return tag;
+    }
 
     public enum ReportType {
         WARNING,

--- a/src/main/java/chaos/unity/nenggao/Span.java
+++ b/src/main/java/chaos/unity/nenggao/Span.java
@@ -3,45 +3,14 @@ package chaos.unity.nenggao;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class Span {
-    public final @NotNull Position startPosition;
-    public final @NotNull Position endPosition;
-
+public class Span extends AbstractSpan {
     public Span(@NotNull Position startPosition, @NotNull Position endPosition) {
-        this.startPosition = startPosition;
-        this.endPosition = endPosition;
+        super(startPosition, endPosition);
     }
 
-    public boolean isMultiLine() {
-        return startPosition.line != endPosition.line;
-    }
-
-    public boolean isIn(int line) {
-        return startPosition.line <= line && line <= endPosition.line;
-    }
-
-    /**
-     * get offset of two position, returns -1 when two positions are in different lines or end position is in front of start position.
-     * @return offset of two position.
-     */
-    public int offset() {
-        if (startPosition.line != endPosition.line || startPosition.pos > endPosition.pos) {
-            return -1;
-        }
-        return endPosition.pos - startPosition.pos;
-    }
-
-    /**
-     * expand copy current instance of {@link Span} and attempt to extend end position to {@code endSpan}.
-     * If {@code endSpan} is null, returns copy of current instance; if {@code endSpan}'s {@link Span#endPosition}
-     * is in front of the current instance's {@link Span#startPosition}, returns copy of current instance, otherwise,
-     * returns a copy of current instance, which its {@link Span#endPosition} is replaced by {@code endSpan}'s
-     * {@link Span#endPosition}.
-     * @param endSpan the span to expand with
-     * @return a copy of current instance, field data would be different based on {@code endSpan}'s data
-     */
-    public @NotNull Span expand(@Nullable Span endSpan) {
-        Span copied = copy();
+    @Override
+    public @NotNull AbstractSpan expand(@Nullable AbstractSpan endSpan) {
+        AbstractSpan copied = copy();
 
         if (endSpan == null)
             return copied;
@@ -59,40 +28,8 @@ public class Span {
         return new Span(startPosition, endPosition);
     }
 
-    public @NotNull Span copy() {
+    @Override
+    public @NotNull AbstractSpan copy() {
         return new Span(startPosition, endPosition);
-    }
-
-    /**
-     * range constructs a span that ignores positions in lines, which is effective when using in source segment capturing.
-     * @param startLineNumber start of range, must be larger than 1.
-     * @param endLineNumber end of range.
-     * @return span based on providing line range
-     */
-    public static Span range(int startLineNumber, int endLineNumber) {
-        return multipleLine(startLineNumber, 0, endLineNumber, 0);
-    }
-
-    /**
-     * singleLine constructs a span that only capture a string in single line.
-     * @param lineNumber start and end line, must be larger than 1.
-     * @param start start of span in line.
-     * @param end end of span in line.
-     * @return span.
-     */
-    public static Span singleLine(int lineNumber, int start, int end) {
-        return new Span(new Position(lineNumber, start), new Position(lineNumber, end));
-    }
-
-    /**
-     * multipleLine constructs a span with full control of all positions.
-     * @param startLineNumber start line, must be larger than 1.
-     * @param start start of span in start line.
-     * @param endLineNumber end line.
-     * @param end end of span in end line.
-     * @return span.
-     */
-    public static Span multipleLine(int startLineNumber, int start, int endLineNumber, int end) {
-        return new Span(new Position(startLineNumber, start), new Position(endLineNumber, end));
     }
 }

--- a/src/main/java/chaos/unity/nenggao/Span.java
+++ b/src/main/java/chaos/unity/nenggao/Span.java
@@ -4,7 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class Span extends AbstractSpan {
-    public Span(@NotNull Position startPosition, @NotNull Position endPosition) {
+    public Span(@NotNull AbstractPosition startPosition, @NotNull AbstractPosition endPosition) {
         super(startPosition, endPosition);
     }
 
@@ -22,8 +22,8 @@ public class Span extends AbstractSpan {
                 return copied;
         }
 
-        Position startPosition = this.startPosition;
-        Position endPosition = endSpan.endPosition;
+        AbstractPosition startPosition = this.startPosition;
+        AbstractPosition endPosition = endSpan.endPosition;
 
         return new Span(startPosition, endPosition);
     }

--- a/src/main/java/chaos/unity/nenggao/Warning.java
+++ b/src/main/java/chaos/unity/nenggao/Warning.java
@@ -4,23 +4,11 @@ import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("unused")
 public class Warning extends Report {
-    public @NotNull String tag = "warning";
-
-    public Warning(@NotNull Position startPosition, @NotNull Position endPosition, @NotNull String message) {
-        super(startPosition, endPosition, ReportType.WARNING, message);
+    public Warning(@NotNull AbstractPosition startPosition, @NotNull AbstractPosition endPosition, @NotNull String message) {
+        super("warning", startPosition, endPosition, ReportType.WARNING, message);
     }
 
-    public Warning(@NotNull Span span, @NotNull String message) {
-        super(span, ReportType.WARNING, message);
-    }
-
-    @Override
-    public void setTag(@NotNull String tag) {
-        this.tag = tag;
-    }
-
-    @Override
-    public @NotNull String getTag() {
-        return tag;
+    public Warning(@NotNull AbstractSpan span, @NotNull String message) {
+        super("warning", span, ReportType.WARNING, message);
     }
 }

--- a/src/test/java/chaos/unity/nenggao/SimpleTest.java
+++ b/src/test/java/chaos/unity/nenggao/SimpleTest.java
@@ -17,9 +17,9 @@ public class SimpleTest {
                 .tag("E01")
                 .label(Span.multipleLine(1, 0, 3, 8), "LOL").color(Attribute.RED_TEXT()).build()
                 .label(Span.multipleLine(2, 0, 5, 0), "KEK").color(Attribute.BRIGHT_MAGENTA_TEXT()).build()
-                .label(Span.singleLine(1, 6, 11), "L").color(Attribute.BRIGHT_CYAN_TEXT()).build()
-                .label(Span.singleLine(3, 0, 4), "impl dude").color(Attribute.BRIGHT_CYAN_TEXT()).build()
-                .label(Span.multipleLine(4, 0, 6, 0), "kek").build()
+                .label(Span.singleLine(1, 6, 11), "L").color(Attribute.BRIGHT_CYAN_TEXT()).hint("Hint L").build()
+                .label(Span.singleLine(3, 0, 4), "impl dude").color(Attribute.BRIGHT_CYAN_TEXT()).hint("impl it!").build()
+                .label(Span.multipleLine(4, 0, 6, 0), "kek").hint("omegalul").build()
                 .build()
                 .print(System.out);
     }


### PR DESCRIPTION
- Resolve #4, makes data-holder classes abstract, including:
- - Span -> AbstractSpan
- - Position -> AbstractPosition
- - Label -> AbstractLabel
- - Error & Warning (partial members) -> Report (field migration only)